### PR TITLE
Correct Platform Descriptor for Windows

### DIFF
--- a/CLionSourceCodeAccess.uplugin
+++ b/CLionSourceCodeAccess.uplugin
@@ -23,7 +23,7 @@
 			"WhitelistPlatforms" :
 			[
 				"Mac",
-				"Windows",
+				"Win64",
 				"Linux"
 			]
 		}


### PR DESCRIPTION
The correct platform for the Windows editor is Win64, not Windows. I couldn't get the plugin to work on Windows without this change.