### PR TITLE
Backslash problem and cmake version update

### DIFF
--- a/Source/CLionSourceCodeAccess/Private/CLionSourceCodeAccessor.cpp
+++ b/Source/CLionSourceCodeAccess/Private/CLionSourceCodeAccessor.cpp
@@ -142,6 +142,7 @@ bool FCLionSourceCodeAccessor::GenerateFromCodeLiteProject()
        IncludeDirectoriesContent.Append(FString::Printf(TEXT("\t\"%s\"\n"), *Line));
     }
     IncludeDirectoriesContent.Append(TEXT(")\ninclude_directories(${INCLUDE_DIRECTORIES})\n"));
+	IncludeDirectoriesContent = IncludeDirectoriesContent.Replace(TEXT("\\"), TEXT("/"));
 
     // Output our Include Directories content and add an entry to the CMakeList
     FString IncludeDirectoriesOutputPath = FPaths::Combine(*ProjectFileOutputFolder, TEXT("IncludeDirectories.cmake"));
@@ -230,6 +231,7 @@ bool FCLionSourceCodeAccessor::GenerateFromCodeLiteProject()
                                                                                                   this->Settings->bIncludePlugins,
                                                                                                   this->Settings->bIncludeShaders);
 
+		WorkingProjectFiles = WorkingProjectFiles.Replace(TEXT("\\"), TEXT("/"));
         // Add file set to the project cmake file (this is so we split things up, so CLion does't have
         // any issues with the file size of one individual file.
         OutputProjectTemplate.Append(FString::Printf(TEXT("set(%s_FILES \n%s)\n"), *SubProjectName, *WorkingProjectFiles));
@@ -350,6 +352,7 @@ FString FCLionSourceCodeAccessor::HandleConfiguration(FXmlNode *CurrentNode, con
             for (FXmlNode* subNode : subchildrenNodes) {
                 if (subNode->GetTag() == TEXT("WorkingDirectory")) {
                     WorkingDirectory = subNode->GetContent();
+					WorkingDirectory = WorkingDirectory.Replace(TEXT("\\"), TEXT("/"));
                 }
 
                 if (subNode->GetTag() == TEXT("BuildCommand")) {
@@ -386,6 +389,7 @@ FString FCLionSourceCodeAccessor::HandleConfiguration(FXmlNode *CurrentNode, con
         }
     }
 
+	ReturnContent = ReturnContent.Replace(TEXT("\\"), TEXT("/"));
     return ReturnContent;
 }
 

--- a/Source/CLionSourceCodeAccess/Private/CLionSourceCodeAccessor.cpp
+++ b/Source/CLionSourceCodeAccess/Private/CLionSourceCodeAccessor.cpp
@@ -60,7 +60,7 @@ bool FCLionSourceCodeAccessor::GenerateFromCodeLiteProject()
     const FString ProjectName = FPaths::GetBaseFilename(ProjectFilePath, true);
 
     // Start our master CMakeList file
-    FString OutputTemplate = TEXT("cmake_minimum_required (VERSION 2.6)\nproject (UE4)\n");
+    FString OutputTemplate = TEXT("cmake_minimum_required (VERSION 2.8.4)\nproject (UE4)\n");
     OutputTemplate.Append(TEXT("set(CMAKE_CXX_STANDARD 11)\n\n"));
 
     // Increase our progress


### PR DESCRIPTION
Used the function replace to change backslash to slash to work in Windows on cmake files that have a path. The cmake version was updated because of a warning that I was receiving.