### PR TITLE
Fixed header include order to satisfy Unreal Engine 4.17 source code formatting.

### DIFF
--- a/Source/CLionSourceCodeAccess/Private/CLionSettings.cpp
+++ b/Source/CLionSourceCodeAccess/Private/CLionSettings.cpp
@@ -1,7 +1,7 @@
 // Copyright 2017 dotBunny Inc. All Rights Reserved.
 
-#include "CLionSourceCodeAccessPrivatePCH.h"
 #include "CLionSettings.h"
+#include "CLionSourceCodeAccessPrivatePCH.h"
 
 #define LOCTEXT_NAMESPACE "CLionSourceCodeAccessor"
 

--- a/Source/CLionSourceCodeAccess/Private/CLionSourceCodeAccessModule.cpp
+++ b/Source/CLionSourceCodeAccess/Private/CLionSourceCodeAccessModule.cpp
@@ -1,11 +1,11 @@
 // Copyright 2017 dotBunny Inc. All Rights Reserved.
 
+#include "CLionSourceCodeAccessModule.h"
 #include "CLionSourceCodeAccessPrivatePCH.h"
 #include "Runtime/Core/Public/Features/IModularFeatures.h"
 #include "Editor/LevelEditor/Public/LevelEditor.h"
 #include "ISettingsModule.h"
 #include "ISettingsSection.h"
-#include "CLionSourceCodeAccessModule.h"
 #include "CLionSettings.h"
 
 #define LOCTEXT_NAMESPACE "CLionSourceCodeAccessor"

--- a/Source/CLionSourceCodeAccess/Private/CLionSourceCodeAccessor.cpp
+++ b/Source/CLionSourceCodeAccess/Private/CLionSourceCodeAccessor.cpp
@@ -1,7 +1,7 @@
 // Copyright 2017 dotBunny, Inc. All Rights Reserved.
 
-#include "CLionSourceCodeAccessPrivatePCH.h"
 #include "CLionSourceCodeAccessor.h"
+#include "CLionSourceCodeAccessPrivatePCH.h"
 
 #define LOCTEXT_NAMESPACE "CLionSourceCodeAccessor"
 


### PR DESCRIPTION
See Issue #75: Unreal Engine 4.17 complains that the header file corresponding to a source file needs to be the first include.