### PR TITLE
Fix check settings for CLion and Mono

### DIFF
--- a/Source/CLionSourceCodeAccess/Private/CLionSettings.cpp
+++ b/Source/CLionSourceCodeAccess/Private/CLionSettings.cpp
@@ -150,6 +150,12 @@ void UCLionSettings::PostEditChangeProperty(struct FPropertyChangedEvent& Proper
 	// CLion Executable Path Check
 	if (MemberPropertyName == GET_MEMBER_NAME_CHECKED(UCLionSettings, CLion))
 	{
+		if (this->CLion.FilePath.IsEmpty())
+		{
+			this->bSetupComplete = false;
+			return;
+		}
+
 		this->CLion.FilePath = FPaths::ConvertRelativePathToFull(this->CLion.FilePath);
 
 		FText FailReason;
@@ -178,6 +184,10 @@ void UCLionSettings::PostEditChangeProperty(struct FPropertyChangedEvent& Proper
 		{
 			FMessageDialog::Open(EAppMsgType::Ok, FailReason);
 			this->CLion.FilePath = this->PreviousCLion;
+			if (this->CLion.FilePath.IsEmpty())
+			{
+				this->bSetupComplete = false;
+			}
 			return;
 		}
 	}
@@ -186,6 +196,12 @@ void UCLionSettings::PostEditChangeProperty(struct FPropertyChangedEvent& Proper
 	// Mono Path
 	if (MemberPropertyName == GET_MEMBER_NAME_CHECKED(UCLionSettings, Mono))
 	{
+		if (this->Mono.FilePath.IsEmpty())
+		{
+			this->bSetupComplete = false;
+			return;
+		}
+
 		this->Mono.FilePath = FPaths::ConvertRelativePathToFull(this->Mono.FilePath);
 
 		FText FailReason;

--- a/Source/CLionSourceCodeAccess/Private/CLionSourceCodeAccessor.cpp
+++ b/Source/CLionSourceCodeAccess/Private/CLionSourceCodeAccessor.cpp
@@ -574,6 +574,11 @@ bool FCLionSourceCodeAccessor::OpenFileAtLine(const FString& FullPath, int32 Lin
 
 bool FCLionSourceCodeAccessor::OpenSolution()
 {
+	if (!this->Settings->IsSetup())
+	{
+		UE_LOG(LogCLionAccessor, Warning, TEXT("Please configure the CLion integration in your project settings."));
+		return false;
+	}
 
 	// TODO: Add check for CMakeProject file, if not there generate
 


### PR DESCRIPTION
Invalid value is set for CLion executable and CLion execution fails.
I fixed to prevent steps 8 and 10 below.

To reproduction

1. Open the CLion settings in Project Settings Window
2. Set the path to the CLion executable
3. Open other settings
4. Open CLion settings
5. Remove the path to the CLion executable
6. Open other settings
7. Open CLion settings
8. UE4 folder path is set in the path to the CLion executable (e.g. `C:\Program Files\Epic Games\UE_4.17\Engine\Binaries\Win64\` )
    * If `CLion.FilePath` is empty, the following returns the working directory of UE4 Editor.
https://github.com/dotBunny/CLionSourceCodeAccess/blob/24f363a89f966d68b49b7c53c3fc7bf2a6b950ca/Source/CLionSourceCodeAccess/Private/CLionSettings.cpp#L153
9. Select Open CLion from File menu
10. Error in Output Log

        LogWindows: Warning: CreateProc failed (5) C:/Program Files/Epic Games/UE_4.17/Engine/Binaries/Win64/ "C:/Users/shiena/Documents/Unreal Projects/MyProjectCpp/"
    * `CLion.FilePath` is not checked before running CLion.
    https://github.com/dotBunny/CLionSourceCodeAccess/blob/4f8b9dc181aab5adf666524624ca77e1555a7d65/Source/CLionSourceCodeAccess/Private/CLionSourceCodeAccessor.cpp#L575-L592
