### PR TITLE
Fix to open file path containing space

### DIFF
--- a/Source/CLionSourceCodeAccess/Private/CLionSourceCodeAccessor.cpp
+++ b/Source/CLionSourceCodeAccess/Private/CLionSourceCodeAccessor.cpp
@@ -617,7 +617,7 @@ bool FCLionSourceCodeAccessor::OpenSourceFiles(const TArray<FString>& AbsoluteSo
 	// Build our paths based on what unreal sends to be opened
 	for (const auto& SourcePath : AbsoluteSourcePaths)
 	{
-		sourceFilesList = FString::Printf(TEXT("%s %s"), *sourceFilesList, *SourcePath);
+		sourceFilesList = FString::Printf(TEXT("%s \"%s\""), *sourceFilesList, *SourcePath);
 	}
 
 	// Trim any whitespace on our source file list


### PR DESCRIPTION
To reproduction

1. Create a project in a path that contains spaces
(e. g. `%USERPROFILE%\Documents\Unreal Projects\MyProject` )
1. Create a C++ class
1. CLion fails to open C++ files
