### PR TITLE
fix 4.18 Unable to produce project files error

### DIFF
--- a/CLionSourceCodeAccess.uplugin
+++ b/CLionSourceCodeAccess.uplugin
@@ -1,8 +1,8 @@
 {
 	"FileVersion" : 3,
-	"EngineVersion" : "4.17.0",
-	"Version" : 106,
-	"VersionName" : "1.06",
+	"EngineVersion" : "4.18.0",
+	"Version" : 107,
+	"VersionName" : "1.07",
 	"FriendlyName" : "CLion Integration",
 	"Description" : "Allows access to source code in CLion.",
 	"Category" : "Programming",

--- a/Source/CLionSourceCodeAccess/CLionSourceCodeAccess.Build.cs
+++ b/Source/CLionSourceCodeAccess/CLionSourceCodeAccess.Build.cs
@@ -34,6 +34,8 @@ namespace UnrealBuildTool.Rules
                     "HotReload",
                 }
             );
+
+            PCHUsage = PCHUsageMode.NoSharedPCHs;
 		}
 	}
 }

--- a/Source/CLionSourceCodeAccess/Private/CLionSettings.cpp
+++ b/Source/CLionSourceCodeAccess/Private/CLionSettings.cpp
@@ -108,7 +108,7 @@ bool UCLionSettings::CheckSettings()
 
 
 	// Update CMakeList path
-	this->CachedCMakeListPath = FPaths::Combine(*FPaths::ConvertRelativePathToFull(*FPaths::GameDir()),
+	this->CachedCMakeListPath = FPaths::Combine(*FPaths::ConvertRelativePathToFull(*FPaths::ProjectDir()),
 	                                            TEXT("CMakeLists.txt"));
 
 	return this->bSetupComplete;

--- a/Source/CLionSourceCodeAccess/Private/CLionSourceCodeAccessor.cpp
+++ b/Source/CLionSourceCodeAccess/Private/CLionSourceCodeAccessor.cpp
@@ -105,13 +105,13 @@ bool FCLionSourceCodeAccessor::GenerateFromCodeLiteProject()
 
 #if PLATFORM_WINDOWS
 	const FString BuildProjectCommand = *UnrealBuildToolPath;
-	const FString BuildProjectParameters = FString::Printf(TEXT("\"%s\" -Game \"%s\" -OnlyPublic -CodeLiteFile -CurrentPlatform -NoShippingConfigs"),
+	const FString BuildProjectParameters = FString::Printf(TEXT("\"%s\" -Game \"%s\" -OnlyPublic -CodeLiteFiles -CurrentPlatform -NoShippingConfigs"),
 											   *ProjectFilePath,
 											   *this->WorkingProjectName);
 #else
 	const FString BuildProjectCommand = *this->Settings->Mono.FilePath;
 	const FString BuildProjectParameters = FString::Printf(
-			TEXT("\"%s\" \"%s\" -Game \"%s\" -OnlyPublic -CodeLiteFile -CurrentPlatform -NoShippingConfigs"),
+			TEXT("\"%s\" \"%s\" -Game \"%s\" -OnlyPublic -CodeLiteFiles -CurrentPlatform -NoShippingConfigs"),
 			*UnrealBuildToolPath,
 			*ProjectFilePath,
 			*this->WorkingProjectName);

--- a/Source/CLionSourceCodeAccess/Private/CLionSourceCodeAccessor.cpp
+++ b/Source/CLionSourceCodeAccess/Private/CLionSourceCodeAccessor.cpp
@@ -598,6 +598,29 @@ bool FCLionSourceCodeAccessor::OpenSolution()
 	return true;
 }
 
+bool FCLionSourceCodeAccessor::OpenSolutionAtPath(const FString& InSolutionPath) {
+	// TODO: Add check for CMakeProject file, if not there generate
+
+	if (this->Settings->bRequireRefresh)
+	{
+		this->GenerateProjectFile();
+	}
+
+	if (this->Settings->bRequireRefresh || !FPaths::FileExists(*this->Settings->GetCMakeListPath()))
+	{
+		this->GenerateProjectFile();
+	}
+
+	if (FPlatformProcess::CreateProc(*this->Settings->CLion.FilePath, *InSolutionPath, true, true, false, nullptr, 0, nullptr,
+	                                 nullptr).IsValid())
+	{
+		// This seems to always fail no matter what we do - could be the process type? Get rid of the warning for now
+		//UE_LOG(LogCLionAccessor, Warning, TEXT("Opening the solution failed."));
+		return false;
+	}
+	return true;
+}
+
 bool FCLionSourceCodeAccessor::OpenSourceFiles(const TArray<FString>& AbsoluteSourcePaths)
 {
 	if (!this->Settings->IsSetup())
@@ -640,6 +663,12 @@ bool FCLionSourceCodeAccessor::OpenSourceFiles(const TArray<FString>& AbsoluteSo
 bool FCLionSourceCodeAccessor::SaveAllOpenDocuments() const
 {
 	// TODO: Implement saving remotely?
+	return true;
+}
+
+bool FCLionSourceCodeAccessor::DoesSolutionExist() const
+{
+	// TODO: check if the solution really exists
 	return true;
 }
 

--- a/Source/CLionSourceCodeAccess/Private/CLionSourceCodeAccessor.cpp
+++ b/Source/CLionSourceCodeAccess/Private/CLionSourceCodeAccessor.cpp
@@ -62,7 +62,7 @@ bool FCLionSourceCodeAccessor::GenerateFromCodeLiteProject()
 	FPaths::NormalizeFilename(UnrealBuildToolPath);
 	FString ProjectFilePath = *FPaths::ConvertRelativePathToFull(*FPaths::GetProjectFilePath());
 	FPaths::NormalizeFilename(ProjectFilePath);
-	FString ProjectPath = *FPaths::ConvertRelativePathToFull(*FPaths::GameDir());
+	FString ProjectPath = *FPaths::ConvertRelativePathToFull(*FPaths::ProjectDir());
 	FPaths::NormalizeFilename(ProjectPath);
 
 	// Assign and filter our project name
@@ -75,7 +75,7 @@ bool FCLionSourceCodeAccessor::GenerateFromCodeLiteProject()
 	// Start our master CMakeList file
 	FString OutputTemplate = TEXT("cmake_minimum_required (VERSION 2.6)\nproject (UE4)\n");
 	OutputTemplate.Append(TEXT("set(CMAKE_CXX_STANDARD 11)\n"));
-  
+
   //Set Response files output
   OutputTemplate.Append(FString::Printf(TEXT("\nSET(CMAKE_CXX_USE_RESPONSE_FILE_FOR_OBJECTS 1 CACHE BOOL \"\" FORCE)")));
   OutputTemplate.Append(FString::Printf(TEXT("\nSET(CMAKE_CXX_USE_RESPONSE_FILE_FOR_INCLUDES 1 CACHE BOOL \"\" FORCE)\n")));
@@ -203,7 +203,7 @@ bool FCLionSourceCodeAccessor::GenerateFromCodeLiteProject()
 	FString IncludeDirectoriesOutputPath = FPaths::Combine(*ProjectFileOutputFolder, TEXT("IncludeDirectories.cmake"));
 	FPaths::NormalizeFilename(IncludeDirectoriesOutputPath);
 	if (!FFileHelper::SaveStringToFile(IncludeDirectoriesContent, *IncludeDirectoriesOutputPath,
-	                                   FFileHelper::EEncodingOptions::Type::ForceAnsi))
+	                                   FFileHelper::EEncodingOptions::ForceAnsi))
 	{
 		UE_LOG(LogCLionAccessor, Error, TEXT("Error writing %s"), *IncludeDirectoriesOutputPath);
 		return false;
@@ -236,7 +236,7 @@ bool FCLionSourceCodeAccessor::GenerateFromCodeLiteProject()
 
 
 		if (!FFileHelper::SaveStringToFile(JSONOutput, *IncludeJSONOutputPath,
-		                                   FFileHelper::EEncodingOptions::Type::ForceAnsi))
+		                                   FFileHelper::EEncodingOptions::ForceAnsi))
 		{
 			UE_LOG(LogCLionAccessor, Error, TEXT("Error writing %s"), *IncludeJSONOutputPath);
 			return false;
@@ -260,7 +260,7 @@ bool FCLionSourceCodeAccessor::GenerateFromCodeLiteProject()
 	// Output our Definitions content and add an entry to the CMakeList
 	FString DefinitionsOutputPath = FPaths::Combine(*ProjectFileOutputFolder, TEXT("Definitions.cmake"));
 	if (!FFileHelper::SaveStringToFile(DefinitionsProcessed, *DefinitionsOutputPath,
-	                                   FFileHelper::EEncodingOptions::Type::ForceAnsi))
+	                                   FFileHelper::EEncodingOptions::ForceAnsi))
 	{
 		UE_LOG(LogCLionAccessor, Error, TEXT("Error writing %s"), *DefinitionsOutputPath);
 		return false;
@@ -353,7 +353,7 @@ bool FCLionSourceCodeAccessor::GenerateFromCodeLiteProject()
 		FString ProjectOutputPath = FPaths::Combine(*ProjectFileOutputFolder,
 		                                            *FString::Printf(TEXT("%s.cmake"), *SubProjectName));
 		if (!FFileHelper::SaveStringToFile(OutputProjectTemplate, *ProjectOutputPath,
-		                                   FFileHelper::EEncodingOptions::Type::ForceAnsi))
+		                                   FFileHelper::EEncodingOptions::ForceAnsi))
 		{
 			UE_LOG(LogCLionAccessor, Error, TEXT("Error writing %s"), *ProjectOutputPath);
 			return false;
@@ -377,7 +377,7 @@ bool FCLionSourceCodeAccessor::GenerateFromCodeLiteProject()
 
 	// Write out the file
 	if (!FFileHelper::SaveStringToFile(OutputTemplate, *this->Settings->GetCMakeListPath(),
-	                                   FFileHelper::EEncodingOptions::Type::ForceAnsi))
+	                                   FFileHelper::EEncodingOptions::ForceAnsi))
 	{
 		UE_LOG(LogCLionAccessor, Error, TEXT("Error writing %s"), *this->Settings->GetCMakeListPath());
 		return false;
@@ -556,7 +556,7 @@ bool FCLionSourceCodeAccessor::OpenFileAtLine(const FString& FullPath, int32 Lin
 
 
 	const FString Path = FString::Printf(TEXT("\"%s\" --line %d \"%s\""),
-	                                     *FPaths::ConvertRelativePathToFull(*FPaths::GameDir()), LineNumber, *FullPath);
+	                                     *FPaths::ConvertRelativePathToFull(*FPaths::ProjectDir()), LineNumber, *FullPath);
 
 
 
@@ -587,7 +587,7 @@ bool FCLionSourceCodeAccessor::OpenSolution()
 		this->GenerateProjectFile();
 	}
 
-	const FString Path = FString::Printf(TEXT("\"%s\""), *FPaths::ConvertRelativePathToFull(*FPaths::GameDir()));
+	const FString Path = FString::Printf(TEXT("\"%s\""), *FPaths::ConvertRelativePathToFull(*FPaths::ProjectDir()));
 	if (FPlatformProcess::CreateProc(*this->Settings->CLion.FilePath, *Path, true, true, false, nullptr, 0, nullptr,
 	                                 nullptr).IsValid())
 	{
@@ -621,7 +621,8 @@ bool FCLionSourceCodeAccessor::OpenSourceFiles(const TArray<FString>& AbsoluteSo
 	}
 
 	// Trim any whitespace on our source file list
-	sourceFilesList = sourceFilesList.Trim();
+	sourceFilesList.TrimStartInline();
+	sourceFilesList.TrimEndInline();
 
 	FProcHandle Proc = FPlatformProcess::CreateProc(*this->Settings->CLion.FilePath, *sourceFilesList, true, false,
 	                                                false, nullptr, 0, nullptr, nullptr);

--- a/Source/CLionSourceCodeAccess/Private/CLionSourceCodeAccessor.h
+++ b/Source/CLionSourceCodeAccess/Private/CLionSourceCodeAccessor.h
@@ -25,6 +25,8 @@ public:
 
 	virtual bool OpenSolution() override;
 
+	virtual bool OpenSolutionAtPath(const FString& InSolutionPath) override;
+
 	virtual bool OpenFileAtLine(const FString& FullPath, int32 LineNumber, int32 ColumnNumber = 0) override;
 
 	virtual bool OpenSourceFiles(const TArray<FString>& AbsoluteSourcePaths) override;
@@ -33,6 +35,8 @@ public:
 	AddSourceFiles(const TArray<FString>& AbsoluteSourcePaths, const TArray<FString>& AvailableModules) override;
 
 	virtual bool SaveAllOpenDocuments() const override;
+
+	virtual bool DoesSolutionExist() const override;
 
 	/**
 	 * Frame Tick (Not Used)


### PR DESCRIPTION
unreal build tool has changed the -codelitefile arg to -codelitefiles

change -codelitefile to  -codelitefiles in CLionSourceCodeAccessor.cpp line 108 and 114

I don't know how to use github. I created this pull request by mistake and I found I can't delete it. T-T. I just want to open a topic or something like that to tell someone troubled by "Unable to produce project files" error how to fix the error. Sorry if this pull request hindered your work.